### PR TITLE
Response error handling

### DIFF
--- a/lib/remarkable_ruby.rb
+++ b/lib/remarkable_ruby.rb
@@ -16,6 +16,7 @@ module RemarkableRuby
   autoload :Highlight, "remarkable_ruby/highlight"
   autoload :Item, "remarkable_ruby/item"
   autoload :ZipDocument, "remarkable_ruby/zip_document"
+  autoload :ResponseHandling, "remarkable_ruby/response_handling"
 
   autoload :Folder, "remarkable_ruby/items/folder"
   autoload :Document, "remarkable_ruby/items/document"

--- a/lib/remarkable_ruby/client.rb
+++ b/lib/remarkable_ruby/client.rb
@@ -1,5 +1,7 @@
 module RemarkableRuby
   class Client
+    include RemarkableRuby::ResponseHandling
+
     APP_URL = "https://webapp-production-dot-remarkable-production.appspot.com/"
     SERVICE_DISCOVERY_URL = "https://service-manager-production-dot-remarkable-production.appspot.com/"
     DEVICE_TOKEN_ENDPOINT = "token/json/2/device/new"
@@ -81,14 +83,6 @@ module RemarkableRuby
     def refresh_user_token
       response = auth_connection.post(USER_TOKEN_ENDPOINT)
       response.body
-    end
-
-    def handle_response(response)
-      status = response.status
-      message = response.body
-      return response if response.status == 200
-
-      raise Error, "HTTP Status Code #{status}: #{message}"
     end
 
     def create_new_items(response)

--- a/lib/remarkable_ruby/client.rb
+++ b/lib/remarkable_ruby/client.rb
@@ -20,7 +20,7 @@ module RemarkableRuby
     # returns metadata for all files
     def documents(download_links: false)
       params = download_links ? { 'withBlob': true } : {}
-      response = connection.get("document-storage/json/2/docs", params)
+      response = handle_response connection.get("document-storage/json/2/docs", params)
       create_new_items(response)
     end
 
@@ -28,7 +28,7 @@ module RemarkableRuby
     def document(uuid:, download_link: false)
       params = download_link ? { 'withBlob': true } : {}
       params[:doc] = uuid
-      response = connection.get("document-storage/json/2/docs", params)
+      response = handle_response connection.get("document-storage/json/2/docs", params)
       attrs = JSON.parse(response.body).first
       Document.new(attrs: attrs)
     end

--- a/lib/remarkable_ruby/item.rb
+++ b/lib/remarkable_ruby/item.rb
@@ -1,5 +1,7 @@
 module RemarkableRuby
   class Item
+    include RemarkableRuby::ResponseHandling
+
     attr_reader :uuid, :path, :message, :success, :blob_url_get, :bookmarked, 
       :blob_url_get_expires, :modified_client, :type, :current_page,
       :connection

--- a/lib/remarkable_ruby/item.rb
+++ b/lib/remarkable_ruby/item.rb
@@ -10,7 +10,6 @@ module RemarkableRuby
 
     def initialize(attrs: nil, client: nil, path: nil)
       @client = client ? client : Client.new
-      @connection = @client.connection
       @path = path
       @name = File.basename(path) if path
 

--- a/lib/remarkable_ruby/items/document.rb
+++ b/lib/remarkable_ruby/items/document.rb
@@ -10,15 +10,8 @@ module RemarkableRuby
       file_name = "#{uuid}.zip"
       return if File.exists?(file_name)
 
-      dl_link = get_blob_url
-
-      streamed = []
-      @connection.get(dl_link) do |req|
-        req.options.on_data = Proc.new { |chunk| streamed << chunk }
-      end
-      File.write(file_name, streamed.join)
-
-      file_name
+      url = blob_url_get
+      download_zip(url, file_name)
     end
 
     # Move a document to the trash folder
@@ -29,7 +22,7 @@ module RemarkableRuby
     # Delete a document from device and cloud
     def delete!
       payload = [{ ID: uuid, Version: version }]
-      response = connection.put("/document-storage/json/2/delete", payload)
+      put_request("/document-storage/json/2/delete", body: payload)
     end
 
     # Return an array of highlights from a document
@@ -47,7 +40,7 @@ module RemarkableRuby
     end
 
     def upload
-      url = put_blob_url
+      url = blob_url_put
       upload_file(url)
       update_metadata(attributes)
     end
@@ -70,8 +63,7 @@ module RemarkableRuby
 
       # Send zip with put http request
       file_data = File.read(zip_doc)
-      connection = @client.upload_connection(url)
-      response = connection.put("", file_data)
+      put_request_to_storage(url, body: file_data)
 
       # Delete zip from temp dir
       FileUtils.remove_entry(zip_doc)
@@ -79,19 +71,43 @@ module RemarkableRuby
 
     def update_metadata(attrs)
       payload = [attrs].to_json
-      @connection.put("document-storage/json/2/upload/update-status", payload)
+      put_request("document-storage/json/2/upload/update-status", body:payload)
     end
 
-    def get_blob_url
+    def get_request(url, params: {}, headers: {})
+      handle_response @client.connection.get(url, params, headers)
+    end
+
+    def put_request(url, body: {}, headers: {})
+      handle_response @client.connection.put(url, body, headers)
+    end
+
+    def put_request_to_storage(url, body: {}, headers: {})
+      connection = @client.upload_connection(url)
+      handle_response connection.put("", body, headers)
+    end
+    
+    def blob_url_get
       params = { doc: uuid, withBlob: true }
-      response = @connection.get("document-storage/json/2/docs", params)
+      response = get_request("document-storage/json/2/docs", params: params)
       JSON.parse(response.body).first['BlobURLGet']
     end
 
-    def put_blob_url
+    def blob_url_put
       payload = [{ "ID": uuid, "Type": type, "Version": version }]
-      response = @connection.put("document-storage/json/2/upload/request", payload)
+      response = put_request("document-storage/json/2/upload/request", body: payload)
       JSON.parse(response.body).first["BlobURLPut"]
+    end
+
+    def download_zip(url, file_name)
+      streamed = []
+      response = @client.connection.get(url) do |req|
+        req.options.on_data = Proc.new { |chunk| streamed << chunk }
+      end
+      handle_response(response)
+      File.write(file_name, streamed.join)
+
+      file_name
     end
   end
 end

--- a/lib/remarkable_ruby/response_handling.rb
+++ b/lib/remarkable_ruby/response_handling.rb
@@ -1,0 +1,26 @@
+module RemarkableRuby
+  module ResponseHandling
+    def handle_response(response)
+      status = response.status
+      body = response.body
+
+      case status
+      when 200
+        response_body = JSON.parse(response.body).first
+        successful = response_body["Success"]
+        message = response_body["Message"]
+        raise Error, message unless successful
+      when 400
+        raise Error, "Your request was malformed. #{body}"
+      when 401
+        raise Error, "Invalid authentication credentials. #{body}"
+      when 403
+        raise Error, "You are not allowed to perform that action. #{body}"
+      when 404
+        raise Error, "No results were found for your request. #{body}"
+      end
+
+      response
+    end
+  end
+end

--- a/lib/remarkable_ruby/response_handling.rb
+++ b/lib/remarkable_ruby/response_handling.rb
@@ -6,6 +6,7 @@ module RemarkableRuby
 
       case status
       when 200
+        # For the responses that fail with a http 200 code
         response_body = JSON.parse(response.body).first
         successful = response_body["Success"]
         message = response_body["Message"]


### PR DESCRIPTION
This is a WIP fix for issues #2 and #10 that adds error handling for the api calls. Right now messages and error types are generic, we may want to make them more specific later on.